### PR TITLE
Large payload fix and more

### DIFF
--- a/src/deepcode/constants/statusCodes.ts
+++ b/src/deepcode/constants/statusCodes.ts
@@ -10,4 +10,3 @@ export const statusCodes: { [key: string]: number } = {
 
 export const EXPIRED_REQUEST = "expiredRequest";
 export const ATTEMPTS_AMMOUNT = 5;
-export const MISSING_CONSENT = "MISSING_CONSENT";

--- a/src/deepcode/lib/modules/BundlesModule.ts
+++ b/src/deepcode/lib/modules/BundlesModule.ts
@@ -3,8 +3,7 @@ import DeepCode from "../../../interfaces/DeepCodeInterfaces";
 import {
   EXPIRED_REQUEST,
   ATTEMPTS_AMMOUNT,
-  statusCodes,
-  MISSING_CONSENT
+  statusCodes
 } from "../../constants/statusCodes";
 import http from "../../http/requests";
 import {
@@ -85,6 +84,7 @@ class BundlesModule extends LoginModule
     );
     await this.checkBundleOnServer(path);
   }
+
   // processing bundles of files hashes
   private async createSingleHashBundle(
     path: string
@@ -157,11 +157,6 @@ class BundlesModule extends LoginModule
       );
       await this.processBundleFromServer(serverBundle, workspacePath);
     } catch (err) {
-      if (err.error === MISSING_CONSENT) {
-        if (this.remoteBundles[workspacePath]) {
-          this.remoteBundles = {};
-        }
-      }
       await this.errorHandler.processError(this, err, {
         workspacePath,
         removedBundle: !!Object.keys(this.remoteBundles).length,
@@ -369,12 +364,6 @@ class BundlesModule extends LoginModule
       });
       await this.processBundleFromServer(extendedServerBundle, workspacePath);
     } catch (err) {
-      if (err.error === MISSING_CONSENT) {
-        if (this.remoteBundles[workspacePath]) {
-          this.remoteBundles = {};
-        }
-      }
-
       this.errorHandler.processError(this, err, {
         workspacePath,
         removedBundle: !!Object.keys(this.remoteBundles).length,

--- a/src/deepcode/messages/deepCodeMessages.ts
+++ b/src/deepcode/messages/deepCodeMessages.ts
@@ -21,6 +21,10 @@ export const deepCodeMessages = {
     msg: "DeepCode encountered a problem.",
     button: "Restart"
   },
+  payloadSizeError: {
+    msg: "The current workspace is too big for DeepCode to process. You can manually exclude files and subdirectories by creating or editing the `.dcignore` file.",
+    button: "Try again"
+  },
   codeReviewFailed: {
     msg: (name: string): string =>
       `Whoops! DeepCode encountered a problem ${

--- a/src/deepcode/utils/bundlesUtils.ts
+++ b/src/deepcode/utils/bundlesUtils.ts
@@ -7,7 +7,7 @@ export const checkIfBundleIsEmpty = (
     | DeepCode.RemoteBundlesCollectionInterface,
   bundlePath?: string
 ): boolean =>
-  !Object.keys(bundlePath ? bundlesBatch[bundlePath] : bundlesBatch).length;
+  !Object.keys(bundlePath ? bundlesBatch[bundlePath] || {} : bundlesBatch).length;
 
 export const extendLocalHashBundle = (
   updatedFiles: Array<{


### PR DESCRIPTION
### Review DCIgnore before! This PR builds on top of it.

In this PR (compared to DCIgnore):
- Fixed some bugs with absolute paths used as if they were just file names.
- Fixed an error where paths were ignored because of ".git" substrings.
- Removed outdated MISSING_CONSENT functionalities.
- Showed a retry error with some explanations if a payload is too big.
- Now when our customizable filter files (.dcignore and .gitignore) are modified, the bundle gets re-hashed and recreated without having to close the editor and re-open it to be effective.
