### PR TITLE
Handle Login for Gitpod case

### DIFF
--- a/src/deepcode/lib/errorHandler/DeepCodeErrorHandler.ts
+++ b/src/deepcode/lib/errorHandler/DeepCodeErrorHandler.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import * as open from "open";
 import {
   statusCodes,
   ATTEMPTS_AMMOUNT

--- a/src/deepcode/lib/modules/LoginModule.ts
+++ b/src/deepcode/lib/modules/LoginModule.ts
@@ -52,7 +52,13 @@ class LoginModule extends BaseDeepCodeModule
         }
         this.token = sessionToken;
 
-        await open(loginURL);
+        let options: open.Options | undefined;
+        if (process.env['GITPOD_WORKSPACE_ID']) {
+            options = {
+                app: ['gp', 'preview']
+            };
+        }
+        await open(loginURL, options);
         return true;
       } catch (err) {
         this.errorHandler.processError(this, err, {


### PR DESCRIPTION
This change adds a little special handling for using the extension in a gitpod.io dev environment. Specifically the login needs to open the URL using `gp preview`.