### PR TITLE
Fixed reporting and update positions

### DIFF
--- a/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
+++ b/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
@@ -207,13 +207,15 @@ class DeepCodeAnalyzer implements DeepCode.AnalyzerInterface {
         this.analysisResultsCollection,
         updatedFile
       );
-      this.analysisResultsCollection[updatedFile.workspace].files[
+      // Opening a project directory instead of a workspace leads to empty updatedFile.workspace field
+      const workspace = updatedFile.workspace || Object.keys(this.analysisResultsCollection)[0];
+      this.analysisResultsCollection[workspace].files[
         updatedFile.filePathInWorkspace
       ] = { ...fileIssuesList };
       if (this.deepcodeReview) {
         const issues = this.createIssuesList({
           fileIssuesList,
-          suggestions: this.analysisResultsCollection[updatedFile.workspace].suggestions,
+          suggestions: this.analysisResultsCollection[workspace].suggestions,
           fileUri: vscode.Uri.file(updatedFile.fullPath)
         });
         this.deepcodeReview.set(vscode.Uri.file(updatedFile.fullPath), [
@@ -224,7 +226,7 @@ class DeepCodeAnalyzer implements DeepCode.AnalyzerInterface {
     } catch (err) {
       extension.errorHandler.processError(extension, err, {
         message: errorsLogs.updateReviewPositions,
-        bundleId: extension.remoteBundles[updatedFile.workspace].bundleId,
+        bundleId: (extension.remoteBundles[updatedFile.workspace] || {}).bundleId,
         data: {
           [updatedFile.filePathInWorkspace]: updatedFile.contentChanges
         }

--- a/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
+++ b/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
@@ -209,9 +209,8 @@ class DeepCodeAnalyzer implements DeepCode.AnalyzerInterface {
       );
       // Opening a project directory instead of a workspace leads to empty updatedFile.workspace field
       const workspace = updatedFile.workspace || Object.keys(this.analysisResultsCollection)[0];
-      this.analysisResultsCollection[workspace].files[
-        updatedFile.filePathInWorkspace
-      ] = { ...fileIssuesList };
+      const filepath = updatedFile.filePathInWorkspace || updatedFile.fullPath.replace(workspace, "");
+      this.analysisResultsCollection[workspace].files[filepath] = { ...fileIssuesList };
       if (this.deepcodeReview) {
         const issues = this.createIssuesList({
           fileIssuesList,

--- a/src/deepcode/lib/modules/ReportModule.ts
+++ b/src/deepcode/lib/modules/ReportModule.ts
@@ -8,7 +8,7 @@ class ReportModule extends BaseDeepCodeModule implements DeepCode.ReportModuleIn
     // return true;
 
     // disabling request sending in dev mode or to self-managed instances.
-    return process.env.NODE_ENV === "production" && this.baseURL === this.defaultBaseURL;
+    return this.baseURL === this.defaultBaseURL;
   }
 
   public async sendError(options: {[key: string]: any}): Promise<void> {

--- a/src/deepcode/utils/analysisUtils.ts
+++ b/src/deepcode/utils/analysisUtils.ts
@@ -94,12 +94,12 @@ export const updateFileReviewResultsPositions = (
   const offsetedline = changesRange.start.line + 1;
   const charOffset = 1;
 
+  // Opening a project directory instead of a workspace leads to empty updatedFile.workspace field
+  const workspace = updatedFile.workspace || Object.keys(analysisResultsCollection)[0];
+  const filepath = updatedFile.filePathInWorkspace || updatedFile.fullPath.replace(workspace, "");
   const fileIssuesList = {
-    ...analysisResultsCollection[updatedFile.workspace].files[
-      updatedFile.filePathInWorkspace
-    ]
+    ...analysisResultsCollection[workspace].files[filepath]
   };
-
   for (const issue in fileIssuesList) {
     for (const [index, position] of fileIssuesList[issue].entries()) {
       const currentLineIsOnEdgeOfIssueRange =


### PR DESCRIPTION
Fixed reporting and updateReviewResultsPositions for non-workspace analysis.

To test the error resolved here:
- open the current master with VSC
- F5 to run debug mode
- On the new VSC window: File -> Open Folder -> open a repo with some suggestions
- Wait for the analysis to finish
- Hover over an issue -> Quick fix -> ignore this issue...
- An error popup is prompted to the user and a Type Error appears in the debug logs

The problem was caused by the fact the extension assumes having a workspace opened and not just a directory. This problem may also occur in other places of the extension if the assumption is the same. 
@Arvi3d For now this is intended to be an hotfix for enabling the event reports and avoiding the error, feel free to schedule a further investigation in a new Jira task.