### PR TITLE
Default dc ignore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dcignore"]
+	path = dcignore
+	url = https://github.com/DeepCodeAI/dcignore.git

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "update": "git submodule update --init --recursive --remote",
+    "compile": "npm run update && tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
     "test": "node ./out/test/runTest.js"

--- a/src/deepcode/DeepCodeExtension.ts
+++ b/src/deepcode/DeepCodeExtension.ts
@@ -10,6 +10,7 @@ class DeepCodeExtension extends DeepCodeLib implements DeepCode.ExtensionInterfa
   public activate(context: vscode.ExtensionContext): void {
     this.store.createStore(context);
     this.statusBarItem.show();
+    this.context = context;
 
     context.subscriptions.push(
       vscode.commands.registerCommand(

--- a/src/deepcode/lib/modules/BaseDeepCodeModule.ts
+++ b/src/deepcode/lib/modules/BaseDeepCodeModule.ts
@@ -12,6 +12,7 @@ import { IDE_NAME } from "../../constants/general";
 
 export default class BaseDeepCodeModule implements DeepCode.BaseDeepCodeModuleInterface {
   public store: DeepCode.ExtensionStoreInterface;
+  public context: vscode.ExtensionContext | undefined;
   public currentWorkspacePath: string;
   public workspacesPaths: Array<string>;
   public hashesBundles: DeepCode.HashesBundlesInterface;

--- a/src/deepcode/lib/modules/BundlesModule.ts
+++ b/src/deepcode/lib/modules/BundlesModule.ts
@@ -101,7 +101,6 @@ class BundlesModule extends LoginModule
     
     pressedButton = await vscode.window.showInformationMessage(dcignoreNotFound.msg, dcignoreNotFound.default, dcignoreNotFound.custom, dcignoreNotFound.ignore);
     
-    console.log("pre createDCIgnore", pressedButton, pressedButton !== dcignoreNotFound.ignore);
     if (pressedButton && pressedButton !== dcignoreNotFound.ignore) {
       const defaultDcIgnore = this.context && `${this.context.extensionPath}/dcignore/default.dcignore`;
       await createDCIgnore(defaultDcIgnore, path, pressedButton === dcignoreNotFound.custom);

--- a/src/deepcode/messages/deepCodeMessages.ts
+++ b/src/deepcode/messages/deepCodeMessages.ts
@@ -9,6 +9,12 @@ export const deepCodeMessages = {
     workspace: "Yes",
     global: "Always yes"
   },
+  dcignoreNotFound: {
+    msg: "No .dcignore was found in this repository, so all the files has been uploaded. Do you want to add a .dcignore file?",
+    ignore: "Ignore",
+    default: "Add default",
+    custom: "Add custom"
+  },
   error: {
     msg: "DeepCode encountered a problem.",
     button: "Restart"

--- a/src/deepcode/messages/deepCodeMessages.ts
+++ b/src/deepcode/messages/deepCodeMessages.ts
@@ -10,7 +10,7 @@ export const deepCodeMessages = {
     global: "Always yes"
   },
   dcignoreNotFound: {
-    msg: "No .dcignore was found in this repository, so all the files has been uploaded. Do you want to add a .dcignore file?",
+    msg: "No dcignore was found in this repository, so all the files has been uploaded. Would you like to add a .dcignore file?",
     ignore: "Ignore",
     default: "Add default",
     custom: "Add custom"

--- a/src/deepcode/utils/filesUtils.ts
+++ b/src/deepcode/utils/filesUtils.ts
@@ -220,7 +220,6 @@ export const createDCIgnore = async (
   path: string,
   custom: boolean
 ) => {
-  console.log("createDCIgnore");
   const customIgnore = [
     "# Write glob rules for ignored files.",
     "# Check syntax on https://deepcode.freshdesk.com/support/solutions/articles/60000531055-how-can-i-ignore-files-or-directories-",

--- a/src/deepcode/utils/filesUtils.ts
+++ b/src/deepcode/utils/filesUtils.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
 import * as nodePath from "path";
+import * as vscode from "vscode";
 import { Buffer } from "buffer";
 import { fs } from "mz";
 import {
@@ -212,4 +213,26 @@ export const splitPayloadIntoChunks = (
   }
 
   return { chunks: true, payload: chunkedPayload };
+};
+
+export const createDCIgnore = async (
+  defaultDcIgnore: string | undefined,
+  path: string,
+  custom: boolean
+) => {
+  console.log("createDCIgnore");
+  const customIgnore = [
+    "# Write glob rules for ignored files.",
+    "# Check syntax on https://deepcode.freshdesk.com/support/solutions/articles/60000531055-how-can-i-ignore-files-or-directories-",
+    "# Check examples on https://github.com/github/gitignore"
+  ].join("\n");
+  const content: Buffer | Uint8Array = custom || !defaultDcIgnore ? 
+    Buffer.from(customIgnore, 'utf8') :
+    await vscode.workspace.fs.readFile(vscode.Uri.file(defaultDcIgnore));
+  
+  const filePath = `${path}/.dcignore`;
+  const openPath = vscode.Uri.file(filePath);
+  await vscode.workspace.fs.writeFile(openPath, content);
+  const doc = await vscode.workspace.openTextDocument(openPath);
+  vscode.window.showTextDocument(doc);
 };


### PR DESCRIPTION
I made it work, although I really don't like the current import system (git submodule -> fs.readFile). It would maybe be better to create a proper wrapper in the DeepCodeAI/dcignore so that the default.dcignore file's content can be staticly imported both in JS and in TS as an exported string and put the whole thing on npm so we can import it right away instead of using git submodules.

However after spending 2 days, I didn't manage to make the second option available, so this is the best effort MVP.

https://deepcodeai.atlassian.net/browse/COL-770?focusedCommentId=11018&oldIssueView=true&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-11018