### PR TITLE
Added blocking icon and fixed post-merge issues.

### DIFF
--- a/src/deepcode/DeepCodeExtension.ts
+++ b/src/deepcode/DeepCodeExtension.ts
@@ -33,7 +33,7 @@ class DeepCodeExtension extends DeepCodeLib implements DeepCode.ExtensionInterfa
     try {
       await fn(...args);
     } catch (error) {
-      this.processError(error, {
+      await this.processError(error, {
         message: errorsLogs.command(name),
       });
     }
@@ -58,6 +58,7 @@ class DeepCodeExtension extends DeepCodeLib implements DeepCode.ExtensionInterfa
         DEEPCODE_OPEN_LOCAL,
         (path: vscode.Uri, range?: vscode.Range) => {
           vscode.window.showTextDocument(path, { selection: range }).then(
+            // no need to wait for processError since then is called asynchronously as well
             () => {}, (err) => this.processError(err, {
               message: errorsLogs.command(DEEPCODE_OPEN_LOCAL),
             })
@@ -102,7 +103,11 @@ class DeepCodeExtension extends DeepCodeLib implements DeepCode.ExtensionInterfa
     context.subscriptions.push(
       vscode.commands.registerCommand(
         DEEPCODE_SETMODE_COMMAND,
-        this.setMode.bind(this)
+        this.executeCommand.bind(
+          this,
+          DEEPCODE_SETMODE_COMMAND,
+          this.setMode.bind(this)
+        )
       )
     );
     
@@ -120,7 +125,11 @@ class DeepCodeExtension extends DeepCodeLib implements DeepCode.ExtensionInterfa
     context.subscriptions.push(
       vscode.commands.registerCommand(
         DEEPCODE_DCIGNORE_COMMAND,
-        createDCIgnoreCommand
+        this.executeCommand.bind(
+          this,
+          DEEPCODE_DCIGNORE_COMMAND,
+          createDCIgnoreCommand
+        )
       )
     );
 

--- a/src/deepcode/constants/general.ts
+++ b/src/deepcode/constants/general.ts
@@ -8,3 +8,5 @@ export const EXECUTION_DEBOUNCE_INTERVAL = 1000; // 1 second
 export const EXECUTION_THROTTLING_INTERVAL = 1000 * 10;// * 60 * 30; // 30 minutes
 export const EXECUTION_PAUSE_INTERVAL = 1000 * 60 * 30; // 30 minutes
 export const REFRESH_VIEW_DEBOUNCE_INTERVAL = 200; // 200 milliseconds
+// If CONNECTION_ERROR_RETRY_INTERVAL is smaller than EXECUTION_DEBOUNCE_INTERVAL it might get swallowed by the debouncer
+export const CONNECTION_ERROR_RETRY_INTERVAL = EXECUTION_DEBOUNCE_INTERVAL * 2 + 1000 * 3;

--- a/src/deepcode/constants/views.ts
+++ b/src/deepcode/constants/views.ts
@@ -1,5 +1,10 @@
-export const DEEPCODE_VIEW_SUPPORT = "deepcode.views.support";
+export const DEEPCODE_VIEW_ERROR = "deepcode.views.error";
+export const DEEPCODE_VIEW_WELCOME = "deepcode.views.welcome";
+export const DEEPCODE_VIEW_TC = "deepcode.views.tc";
+export const DEEPCODE_VIEW_EMPTY = "deepcode.views.empty";
 export const DEEPCODE_VIEW_ANALYSIS = "deepcode.views.analysis";
+export const DEEPCODE_VIEW_SUPPORT = "deepcode.views.support";
+export const DEEPCODE_VIEW_ACTIONS = "deepcode.views.actions";
 
 // Having multiple boolean contexts instead of a single context 
 // with multiple values helps us to avoid flickering UI.

--- a/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
+++ b/src/deepcode/lib/analyzer/DeepCodeAnalyzer.ts
@@ -219,7 +219,7 @@ class DeepCodeAnalyzer implements DeepCode.AnalyzerInterface {
         this.setIssuesMarkersDecoration();
       }
     } catch (err) {
-      extension.processError(err, {
+      await extension.processError(err, {
         message: errorsLogs.updateReviewPositions,
         bundleId: (extension.remoteBundles[updatedFile.workspace] || {}).bundleId,
         data: {

--- a/src/deepcode/lib/modules/BundlesModule.ts
+++ b/src/deepcode/lib/modules/BundlesModule.ts
@@ -102,6 +102,7 @@ abstract class BundlesModule extends LoginModule
 
   onError(error: Error) {
     this.terminateAnalysis();
+    // no need to wait for processError since onError is called asynchronously as well
     this.processError(error, {
       message: errorsLogs.failedServiceAI,
     });
@@ -137,7 +138,7 @@ abstract class BundlesModule extends LoginModule
     try {
       this.serverFilesFilterList = await http.getFilters(this.baseURL, this.token);
     } catch (err) {
-      this.processError(err, {
+      await this.processError(err, {
         message: errorsLogs.filtersFiles
       })
     }
@@ -155,7 +156,7 @@ abstract class BundlesModule extends LoginModule
     if (!Object.keys(this.serverFilesFilterList).length) {
       await this.createFilesFilterList();
       if (!Object.keys(this.serverFilesFilterList).length) {
-        this.processError(new Error(errorsLogs.filtersFiles), {
+        await this.processError(new Error(errorsLogs.filtersFiles), {
           message: errorsLogs.filtersFiles,
           data: {
             filters: this.serverFilesFilterList
@@ -202,6 +203,7 @@ abstract class BundlesModule extends LoginModule
     });
 
     http.analyse(this.baseURL, this.token, path, this.files, removedFiles).catch(
+      // no need to wait for processError since catch is called asynchronously as well
       (error) => this.processError(error, {
         message: errorsLogs.analyse
       })

--- a/src/deepcode/lib/modules/DeepCodeLib.ts
+++ b/src/deepcode/lib/modules/DeepCodeLib.ts
@@ -44,6 +44,7 @@ export default class DeepCodeLib extends BundlesModule implements DeepCode.DeepC
   private async executeExtensionPipeline(): Promise<void> {
     console.log("DeepCode: starting execution pipeline");
     await setContext(DEEPCODE_CONTEXT.ERROR, false);
+    await this.setLoadingBadge();
     
     const loggedIn = await this.checkSession();
     if (!loggedIn) return;
@@ -70,7 +71,7 @@ export default class DeepCodeLib extends BundlesModule implements DeepCode.DeepC
       try {
         await this.executeExtensionPipeline();
       } catch (err) {
-        this.processError(err, {
+        await this.processError(err, {
           message: errorsLogs.failedExecutionDebounce,
         });
       }
@@ -79,10 +80,10 @@ export default class DeepCodeLib extends BundlesModule implements DeepCode.DeepC
     { 'leading': true }
   );
 
-  setMode(mode: string): void {
+  async setMode(mode: string): Promise<void> {
     if (!Object.values(DEEPCODE_MODE_CODES).includes(mode)) return;
     this._mode = mode;
-    setContext(DEEPCODE_CONTEXT.MODE, mode);
+    await setContext(DEEPCODE_CONTEXT.MODE, mode);
     switch(mode) {
       case DEEPCODE_MODE_CODES.PAUSED:
         this._unpauseTimeout = setTimeout(this.unpause.bind(this), EXECUTION_PAUSE_INTERVAL);

--- a/src/deepcode/messages/errorsServerLogMessages.ts
+++ b/src/deepcode/messages/errorsServerLogMessages.ts
@@ -26,4 +26,5 @@ export const errorsLogs = {
   command: (type: string) => `Failed to execute ${type} command`,
   sendEvent: "Failed to send event to server",
   configWatcher: "Failed to handle configuration update",
+  loadingBadge: "Failed to set loading badge icon on analysis view",
 };

--- a/src/deepcode/utils/vscodeCommandsUtils.ts
+++ b/src/deepcode/utils/vscodeCommandsUtils.ts
@@ -20,8 +20,8 @@ export const viewInBrowser = async (url: string): Promise<void> => {
   await vscode.commands.executeCommand(DEEPCODE_OPEN_BROWSER, url);
 };
 
-export const createDCIgnoreCommand = (custom = false, path?: string): void => {
+export const createDCIgnoreCommand = async (custom = false, path?: string): Promise<void> => {
   path = path || vscode.workspace.rootPath;
   if (!path) return;
-  createDCIgnore(path, custom).catch(console.error);
+  await createDCIgnore(path, custom);
 };

--- a/src/interfaces/DeepCodeInterfaces.ts
+++ b/src/interfaces/DeepCodeInterfaces.ts
@@ -190,6 +190,7 @@ namespace DeepCode {
     filesWatcher: DeepCodeWatcherInterface;
     workspacesWatcher: DeepCodeWatcherInterface;
     settingsWatcher: DeepCodeWatcherInterface;
+    setLoadingBadge(viewId?: string): Promise<void>
     
     // Abstract methods
     processError(


### PR DESCRIPTION
Designs:
- process error should be safely called without risking rejections
- process error should be always awaited in the main execution flow (it may be called asynchronously only inside an asynchronous callback)
- every time an action is required from the user, show the busy notification badge (login, approve upload, blocking error)