### PR TITLE
Mainline updates phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,29 +106,8 @@
     "views": {
       "deepcode": [
         {
-          "id": "deepcode.views.error",
-          "name": "DeepCode Extension",
-          "when": "deepcode:error"
-        },
-        {
-          "id": "deepcode.views.welcome",
-          "name": "DeepCode Extension",
-          "when": "!deepcode:error && !deepcode:loggedIn"
-        },
-        {
-          "id": "deepcode.views.tc",
-          "name": "DeepCode Extension",
-          "when": "!deepcode:error && deepcode:loggedIn && !deepcode:uploadApproved"
-        },
-        {
-          "id": "deepcode.views.empty",
-          "name": "DeepCode Extension",
-          "when": "!deepcode:error && deepcode:loggedIn && deepcode:uploadApproved && !deepcode:workspaceFound"
-        },
-        {
           "id": "deepcode.views.analysis",
-          "name": "DeepCode Analysis",
-          "when": "!deepcode:error && deepcode:loggedIn && deepcode:uploadApproved && deepcode:workspaceFound"
+          "name": "DeepCode Analysis"
         },
         {
           "id": "deepcode.views.actions",
@@ -143,30 +122,34 @@
     },
     "viewsWelcome": [
       {
-        "view": "deepcode.views.error",
+        "view": "deepcode.views.analysis",
         "contents": "DeepCode is temporarily unavailable\nWe are automatically retrying to connect...",
         "when": "deepcode:error == 'transient'"
       },
       {
-        "view": "deepcode.views.error",
+        "view": "deepcode.views.analysis",
         "contents": "DeepCode has encountered a problem. Please restart the extension: \n[Restart](command:deepcode.start 'Restart DeepCode')\nIf the error persists, please check your [settings](command:deepcode.settings) and [contact us](https://www.deepcode.ai/feedback?select=2?utm_source=vsc)!",
-        "when": "deepcode:error != 'transient'"
-      },
-      {
-        "view": "deepcode.views.welcome",
-        "contents": "Welcome to DeepCode for Visual Studio Code. 👋\nLet's start by connecting VS Code with DeepCode:\n[Connect VS Code with DeepCode](command:deepcode.login 'Connect with DeepCode')\n👉 DeepCode's mission is to finds bugs, fast. Connect with DeepCode to start your first analysis!"
-      },
-      {
-        "view": "deepcode.views.tc",
-        "contents": "Thanks for connecting with DeepCode. ✅\n 👉 You are almost set 🤗. DeepCode is analysing the code remotely on DeepCode's servers (our [terms](https://www.deepcode.ai/tc?utm_source=vsc)). Let's confirm you know this and start the analysis.\n[Accept and start analysing](command:deepcode.approve 'Upload code to DeepCode')\nYou can always change it in the [configuration panel](command:deepcode.settings)."
-      },
-      {
-        "view": "deepcode.views.empty",
-        "contents": "Open a workspace or a folder in Visual Studio Code to start the analysis."
+        "when": "deepcode:error == 'blocking'"
       },
       {
         "view": "deepcode.views.analysis",
-        "contents": "DeepCode analyzed your code and found no issue! 🎉"
+        "contents": "Welcome to DeepCode for Visual Studio Code. 👋\nLet's start by connecting VS Code with DeepCode:\n[Connect VS Code with DeepCode](command:deepcode.login 'Connect with DeepCode')\n👉 DeepCode's mission is to finds bugs, fast. Connect with DeepCode to start your first analysis!",
+        "when": "!deepcode:error && !deepcode:loggedIn"
+      },
+      {
+        "view": "deepcode.views.analysis",
+        "contents": "Thanks for connecting with DeepCode. ✅\n 👉 You are almost set 🤗. DeepCode is analysing the code remotely on DeepCode's servers (our [terms](https://www.deepcode.ai/tc?utm_source=vsc)). Let's confirm you know this and start the analysis.\n[Accept and start analysing](command:deepcode.approve 'Upload code to DeepCode')\nYou can always change it in the [configuration panel](command:deepcode.settings).",
+        "when": "!deepcode:error && deepcode:loggedIn && !deepcode:uploadApproved"
+      },
+      {
+        "view": "deepcode.views.analysis",
+        "contents": "Open a workspace or a folder in Visual Studio Code to start the analysis.",
+        "when": "!deepcode:error && deepcode:loggedIn && deepcode:uploadApproved && !deepcode:workspaceFound"
+      },
+      {
+        "view": "deepcode.views.analysis",
+        "contents": "DeepCode analyzed your code and found no issue! 🎉",
+        "when": "!deepcode:error && deepcode:loggedIn && deepcode:uploadApproved && deepcode:workspaceFound"
       },
       {
         "view": "deepcode.views.actions",

--- a/src/deepcode/constants/views.ts
+++ b/src/deepcode/constants/views.ts
@@ -1,7 +1,3 @@
-export const DEEPCODE_VIEW_ERROR = "deepcode.views.error";
-export const DEEPCODE_VIEW_WELCOME = "deepcode.views.welcome";
-export const DEEPCODE_VIEW_TC = "deepcode.views.tc";
-export const DEEPCODE_VIEW_EMPTY = "deepcode.views.empty";
 export const DEEPCODE_VIEW_ANALYSIS = "deepcode.views.analysis";
 export const DEEPCODE_VIEW_SUPPORT = "deepcode.views.support";
 export const DEEPCODE_VIEW_ACTIONS = "deepcode.views.actions";

--- a/src/deepcode/lib/modules/BaseDeepCodeModule.ts
+++ b/src/deepcode/lib/modules/BaseDeepCodeModule.ts
@@ -138,7 +138,6 @@ export default abstract class BaseDeepCodeModule implements DeepCode.BaseDeepCod
 
   // Leave viewId undefined to remove the badge from all views
   async setLoadingBadge(value: boolean): Promise<void> {
-    console.error("setLoadingBadge", value);
     if (this.progressBadgeResolveFn) this.progressBadgeResolveFn();
     if (value) {
       // Using closure on this to allow partial binding in arbitrary positions

--- a/src/deepcode/lib/modules/BaseDeepCodeModule.ts
+++ b/src/deepcode/lib/modules/BaseDeepCodeModule.ts
@@ -138,6 +138,8 @@ export default abstract class BaseDeepCodeModule implements DeepCode.BaseDeepCod
 
   // Leave viewId undefined to remove the badge from all views
   async setLoadingBadge(value: boolean): Promise<void> {
+    console.error("setLoadingBadge", value);
+    if (this.progressBadgeResolveFn) this.progressBadgeResolveFn();
     if (value) {
       // Using closure on this to allow partial binding in arbitrary positions
       const self = this;
@@ -151,7 +153,6 @@ export default abstract class BaseDeepCodeModule implements DeepCode.BaseDeepCod
         })
       );
     } else {
-      if (this.progressBadgeResolveFn) this.progressBadgeResolveFn();
       this.progressBadgePromise = undefined;
       this.progressBadgeResolveFn = undefined;
     }

--- a/src/deepcode/lib/modules/BundlesModule.ts
+++ b/src/deepcode/lib/modules/BundlesModule.ts
@@ -7,7 +7,6 @@ import { checkIfBundleIsEmpty } from "../../utils/bundlesUtils";
 import { createListOfDirFiles } from "../../utils/packageUtils";
 import { BUNDLE_EVENTS } from "../../constants/events";
 import LoginModule from "../../lib/modules/LoginModule";
-import { setContext } from "../../utils/vscodeCommandsUtils";
 import { DEEPCODE_ANALYSIS_STATUS, DEEPCODE_CONTEXT } from "../../constants/views";
 import { errorsLogs } from "../../messages/errorsServerLogMessages";
 
@@ -288,14 +287,14 @@ abstract class BundlesModule extends LoginModule
     try {
       const workspaceFolders: readonly vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || !workspaceFolders.length) {
-        await setContext(DEEPCODE_CONTEXT.ANALYZING, false);
+        await this.setContext(DEEPCODE_CONTEXT.ANALYZING, false);
         return;
       }
 
       this.createWorkspacesList(workspaceFolders);
 
       if (this.workspacesPaths.length) {
-        await setContext(DEEPCODE_CONTEXT.ANALYZING, true);
+        await this.setContext(DEEPCODE_CONTEXT.ANALYZING, true);
         this.updateCurrentWorkspacePath(this.workspacesPaths[0]);
 
         await this.updateHashesBundles();
@@ -303,7 +302,7 @@ abstract class BundlesModule extends LoginModule
           await this.performBundlesActions(path);
         }
       } else {
-        await setContext(DEEPCODE_CONTEXT.ANALYZING, false);
+        await this.setContext(DEEPCODE_CONTEXT.ANALYZING, false);
       }
     } catch(err) {
       await this.processError(err, {

--- a/src/deepcode/lib/modules/DeepCodeLib.ts
+++ b/src/deepcode/lib/modules/DeepCodeLib.ts
@@ -1,7 +1,6 @@
 import * as _ from "lodash";
 import DeepCode from "../../../interfaces/DeepCodeInterfaces";
 import BundlesModule from "./BundlesModule";
-import { setContext } from "../../utils/vscodeCommandsUtils";
 import { DEEPCODE_CONTEXT, DEEPCODE_MODE_CODES } from "../../constants/views";
 import { errorsLogs } from "../../messages/errorsServerLogMessages";
 import { 
@@ -43,8 +42,8 @@ export default class DeepCodeLib extends BundlesModule implements DeepCode.DeepC
 
   private async executeExtensionPipeline(): Promise<void> {
     console.log("DeepCode: starting execution pipeline");
-    await setContext(DEEPCODE_CONTEXT.ERROR, false);
-    await this.setLoadingBadge();
+    await this.setContext(DEEPCODE_CONTEXT.ERROR, false);
+    await this.setLoadingBadge(false);
     
     const loggedIn = await this.checkSession();
     if (!loggedIn) return;
@@ -83,7 +82,7 @@ export default class DeepCodeLib extends BundlesModule implements DeepCode.DeepC
   async setMode(mode: string): Promise<void> {
     if (!Object.values(DEEPCODE_MODE_CODES).includes(mode)) return;
     this._mode = mode;
-    await setContext(DEEPCODE_CONTEXT.MODE, mode);
+    await this.setContext(DEEPCODE_CONTEXT.MODE, mode);
     switch(mode) {
       case DEEPCODE_MODE_CODES.PAUSED:
         this._unpauseTimeout = setTimeout(this.unpause.bind(this), EXECUTION_PAUSE_INTERVAL);

--- a/src/deepcode/lib/modules/LoginModule.ts
+++ b/src/deepcode/lib/modules/LoginModule.ts
@@ -2,12 +2,8 @@ import * as vscode from "vscode";
 import ReportModule from "./ReportModule";
 import DeepCode from "../../../interfaces/DeepCodeInterfaces";
 import http from "../../http/requests";
-import { setContext, viewInBrowser } from "../../utils/vscodeCommandsUtils";
-import {
-  DEEPCODE_VIEW_WELCOME,
-  DEEPCODE_VIEW_TC,
-  DEEPCODE_CONTEXT
-} from "../../constants/views";
+import { viewInBrowser } from "../../utils/vscodeCommandsUtils";
+import { DEEPCODE_CONTEXT } from "../../constants/views";
 import { openDeepcodeViewContainer } from "../../utils/vscodeCommandsUtils";
 import { errorsLogs } from "../../messages/errorsServerLogMessages";
 import { deepCodeMessages } from "../../messages/deepCodeMessages";
@@ -48,14 +44,14 @@ abstract class LoginModule extends ReportModule implements DeepCode.LoginModuleI
     if (this.token) {
       try {
         validSession = !!(await http.checkSession(this.baseURL, this.token));
-        if (!validSession) await this.setLoadingBadge(DEEPCODE_VIEW_WELCOME);
+        if (!validSession) await this.setLoadingBadge(true);
       } catch (err) {
         await this.processError(err, {
           message: errorsLogs.loginStatus
         });
       }
     }
-    await setContext(DEEPCODE_CONTEXT.LOGGEDIN, validSession);
+    await this.setContext(DEEPCODE_CONTEXT.LOGGEDIN, validSession);
     return validSession;
   }
 
@@ -74,14 +70,14 @@ abstract class LoginModule extends ReportModule implements DeepCode.LoginModuleI
 
   async checkApproval(): Promise<boolean> {
     const approved = this.uploadApproved;
-    await setContext(DEEPCODE_CONTEXT.APPROVED, approved);
-    if (!approved) await this.setLoadingBadge(DEEPCODE_VIEW_TC);
+    await this.setContext(DEEPCODE_CONTEXT.APPROVED, approved);
+    if (!approved) await this.setLoadingBadge(true);
     return approved;
   }
 
   async approveUpload(): Promise<void> {
     await this.setUploadApproved(true);
-    await this.setLoadingBadge();
+    await this.setLoadingBadge(false);
     await this.checkApproval();
   }
 
@@ -99,7 +95,7 @@ abstract class LoginModule extends ReportModule implements DeepCode.LoginModuleI
   }
 
   async checkAdvancedMode(): Promise<void> {
-    await setContext(DEEPCODE_CONTEXT.ADVANCED, this.shouldShowAdvancedView);
+    await this.setContext(DEEPCODE_CONTEXT.ADVANCED, this.shouldShowAdvancedView);
   }
 }
 

--- a/src/deepcode/lib/modules/LoginModule.ts
+++ b/src/deepcode/lib/modules/LoginModule.ts
@@ -44,7 +44,6 @@ abstract class LoginModule extends ReportModule implements DeepCode.LoginModuleI
     if (this.token) {
       try {
         validSession = !!(await http.checkSession(this.baseURL, this.token));
-        if (!validSession) await this.setLoadingBadge(true);
       } catch (err) {
         await this.processError(err, {
           message: errorsLogs.loginStatus
@@ -52,6 +51,7 @@ abstract class LoginModule extends ReportModule implements DeepCode.LoginModuleI
       }
     }
     await this.setContext(DEEPCODE_CONTEXT.LOGGEDIN, validSession);
+    if (!validSession) await this.setLoadingBadge(true);
     return validSession;
   }
 

--- a/src/deepcode/lib/modules/ReportModule.ts
+++ b/src/deepcode/lib/modules/ReportModule.ts
@@ -3,8 +3,7 @@ import http from "../../http/requests";
 import BaseDeepCodeModule from "./BaseDeepCodeModule";
 import { statusCodes } from "../../constants/statusCodes";
 import { errorsLogs } from "../../messages/errorsServerLogMessages";
-import { setContext } from "../../utils/vscodeCommandsUtils";
-import { DEEPCODE_CONTEXT, DEEPCODE_ERROR_CODES, DEEPCODE_VIEW_ERROR } from "../../constants/views";
+import { DEEPCODE_CONTEXT, DEEPCODE_ERROR_CODES } from "../../constants/views";
 import { MAX_CONNECTION_RETRIES, CONNECTION_ERROR_RETRY_INTERVAL } from "../../constants/general";
 
 abstract class ReportModule extends BaseDeepCodeModule implements DeepCode.ReportModuleInterface {
@@ -117,15 +116,15 @@ abstract class ReportModule extends BaseDeepCodeModule implements DeepCode.Repor
 
   private async generalErrorHandler(): Promise<void> {
     this.transientErrors = 0;
-    await setContext(DEEPCODE_CONTEXT.ERROR, DEEPCODE_ERROR_CODES.BLOCKING);
-    await this.setLoadingBadge(DEEPCODE_VIEW_ERROR);
+    await this.setContext(DEEPCODE_CONTEXT.ERROR, DEEPCODE_ERROR_CODES.BLOCKING);
+    await this.setLoadingBadge(true);
   }
 
   private async connectionErrorHandler(): Promise<void> {
     if (this.transientErrors > MAX_CONNECTION_RETRIES) return this.generalErrorHandler();
     
     ++this.transientErrors;
-    await setContext(DEEPCODE_CONTEXT.ERROR, DEEPCODE_ERROR_CODES.TRANSIENT);
+    await this.setContext(DEEPCODE_CONTEXT.ERROR, DEEPCODE_ERROR_CODES.TRANSIENT);
     setTimeout(() => {
       this.startExtension().catch((err) => this.processError(err, {
         message: errorsLogs.failedExecutionTransient,

--- a/src/deepcode/utils/pendingTask.ts
+++ b/src/deepcode/utils/pendingTask.ts
@@ -1,0 +1,32 @@
+export interface PendingTaskInterface {
+  waiter: Promise<void>;
+  isCompleted: boolean;
+  complete(): void;
+};
+
+export class PendingTask implements PendingTaskInterface {
+  private _promise: Promise<void>;
+  private _resolve: (() => void) | undefined;
+  private _resolved: boolean;
+
+  constructor() {
+    this._resolved = false;
+    this._promise = new Promise((resolve) => {
+      this._resolve = resolve;
+    }).then((nullValue) => {
+      this._resolved = true;
+    });
+  }
+
+  get waiter(): Promise<void> {
+    return this._promise;
+  }
+
+  get isCompleted(): boolean {
+    return this._resolved;
+  }
+
+  complete(): void {
+    if (this._resolve !== undefined) this._resolve();
+  }
+}

--- a/src/deepcode/utils/vscodeCommandsUtils.ts
+++ b/src/deepcode/utils/vscodeCommandsUtils.ts
@@ -17,7 +17,6 @@ export const openDeepcodeViewContainer = async (): Promise<void> => {
 };
 
 export const setContext = async (key: string, value: unknown): Promise<void> => {
-  console.log("DeepCode context", key, value);
   await vscode.commands.executeCommand('setContext', `${DEEPCODE_CONTEXT_PREFIX}${key}`, value);
 };
 

--- a/src/deepcode/view/IssueProvider.ts
+++ b/src/deepcode/view/IssueProvider.ts
@@ -49,7 +49,10 @@ export class IssueProvider extends NodeProvider {
   getRootChildren(): Node[] {
     const review: Node[] = [];
     let nIssues = 0;
-    if (!this.extension.analyzer.deepcodeReview) return review;
+    if (
+      !this.extension.shouldShowAnalysis ||
+      !this.extension.analyzer.deepcodeReview
+    ) return review;
     this.extension.analyzer.deepcodeReview.forEach(
       (uri: Uri, diagnostics: readonly Diagnostic[]): void => {
         const counts: ISeverityCounts = {

--- a/src/deepcode/view/IssueProvider.ts
+++ b/src/deepcode/view/IssueProvider.ts
@@ -47,6 +47,7 @@ export class IssueProvider extends NodeProvider {
   }
 
   getRootChildren(): Node[] {
+    this.extension.emitViewInitialized();
     const review: Node[] = [];
     let nIssues = 0;
     if (

--- a/src/interfaces/DeepCodeInterfaces.ts
+++ b/src/interfaces/DeepCodeInterfaces.ts
@@ -190,8 +190,10 @@ namespace DeepCode {
     filesWatcher: DeepCodeWatcherInterface;
     workspacesWatcher: DeepCodeWatcherInterface;
     settingsWatcher: DeepCodeWatcherInterface;
-    setLoadingBadge(viewId?: string): Promise<void>
-    
+    setLoadingBadge(value: boolean): Promise<void>
+    setContext(key: string, value: unknown): Promise<void>;
+    shouldShowAnalysis: boolean;
+
     // Abstract methods
     processError(
       error: errorType,

--- a/src/interfaces/DeepCodeInterfaces.ts
+++ b/src/interfaces/DeepCodeInterfaces.ts
@@ -193,6 +193,7 @@ namespace DeepCode {
     setLoadingBadge(value: boolean): Promise<void>
     setContext(key: string, value: unknown): Promise<void>;
     shouldShowAnalysis: boolean;
+    emitViewInitialized(): void;
 
     // Abstract methods
     processError(


### PR DESCRIPTION
- Merged the alternative views into one (deepcode.view.analysis)
- Added standard deferred execution logic (PendingTask)
- Added deferred trigger for progress badge after the user opens the analysis view

This should help visibility and communication if the user moves the mini-dashboard around the vscode UI.